### PR TITLE
fix: import crypto for refresh token

### DIFF
--- a/apps/api/src/modules/auth/auth.service.ts
+++ b/apps/api/src/modules/auth/auth.service.ts
@@ -3,6 +3,7 @@ import { PrismaClient } from '@prisma/client';
 import { JwtService } from '@nestjs/jwt';
 import * as argon2 from 'argon2';
 import Redis from 'ioredis';
+import { randomUUID } from 'crypto';
 
 type AccessClaims = {
   sub: string;
@@ -62,7 +63,7 @@ export class AuthService {
   }
 
   async issueRefresh(userId: string) {
-    const tokenId = crypto.randomUUID();
+    const tokenId = randomUUID();
     const ttl = 60 * 60 * 24 * 14; // 14d
     await this.redis.setex(`refresh:${tokenId}`, ttl, userId);
     return tokenId;


### PR DESCRIPTION
## Summary
- import Node's `randomUUID` to issue refresh tokens without runtime errors

## Testing
- `pnpm --filter api build` *(fails: Invalid package manager specification in package.json)*
- `npm --prefix apps/api run build` *(fails: sh: 1: nest: not found)*
- `npx tsc -p apps/api/tsconfig.json` *(fails: TS2305: Module "@prisma/client" has no exported member 'IdentityType', TS7006: Parameter 'i' implicitly has an 'any' type, TS7006: Parameter 'm' implicitly has an 'any' type, TS2322: Type 'unknown[]' is not assignable to type 'string[]')*

------
https://chatgpt.com/codex/tasks/task_e_689996518690832b8f959b387e6b9cb6