### PR TITLE
feat: add multi-end login and logout

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -15,15 +15,16 @@ enum IdentityType {
 
 model UserAccount {
   id            String   @id @default(cuid())
-  email         String   @unique
+  email         String?  @unique
   phone         String?  @unique
-  passwordHash  String
+  passwordHash  String?
   isActive      Boolean  @default(true)
   createdAt     DateTime @default(now())
   updatedAt     DateTime @updatedAt
 
   identities Identity[]
   memberships Membership[]
+  providers  UserProvider[]
 }
 
 model Tenant {
@@ -94,4 +95,17 @@ model Membership {
 
   @@unique([userId, tenantId, roleId])
   @@index([userId, tenantId])
+}
+
+model UserProvider {
+  id        String   @id @default(cuid())
+  userId    String
+  provider  String
+  openId    String
+  unionId   String?
+  createdAt DateTime @default(now())
+
+  user UserAccount @relation(fields: [userId], references: [id])
+
+  @@unique([provider, openId])
 }

--- a/apps/api/src/modules/auth/auth.controller.ts
+++ b/apps/api/src/modules/auth/auth.controller.ts
@@ -15,6 +15,10 @@ class RefreshDto {
   refreshToken!: string;
 }
 
+class WechatLoginDto {
+  code!: string;
+}
+
 class SwitchIdentityDto {
   identityId!: string;
   tenantId?: string;
@@ -34,12 +38,29 @@ export class AuthController {
     return { accessToken, refreshToken, identities };
   }
 
+  @Post('auth/login/wechat')
+  @HttpCode(200)
+  async loginWechat(@Body() dto: WechatLoginDto) {
+    const user = await this.auth.loginWithWechat(dto.code);
+    const accessToken = await this.auth.issueAccess(user.id);
+    const refreshToken = await this.auth.issueRefresh(user.id);
+    const identities = await this.identity.listUserIdentities(user.id);
+    return { accessToken, refreshToken, identities };
+  }
+
   @Post('auth/refresh')
   @HttpCode(200)
   async refresh(@Body() dto: RefreshDto) {
     const userId = await this.auth.verifyRefresh(dto.refreshToken);
     const accessToken = await this.auth.issueAccess(userId);
     return { accessToken };
+  }
+
+  @Post('auth/logout')
+  @HttpCode(200)
+  async logout(@Body() dto: RefreshDto) {
+    await this.auth.logout(dto.refreshToken);
+    return { ok: true };
   }
 
   @UseGuards(JwtAccessGuard)

--- a/apps/api/src/modules/auth/auth.service.ts
+++ b/apps/api/src/modules/auth/auth.service.ts
@@ -1,8 +1,10 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient, IdentityType } from '@prisma/client';
 import { JwtService } from '@nestjs/jwt';
 import * as argon2 from 'argon2';
 import Redis from 'ioredis';
+import * as https from 'https';
+import { randomUUID } from 'crypto';
 
 type AccessClaims = {
   sub: string;
@@ -22,7 +24,9 @@ export class AuthService {
 
   async validateUser(email: string, password: string) {
     const user = await this.prisma.userAccount.findUnique({ where: { email } });
-    if (!user || !user.isActive) throw new UnauthorizedException('Invalid credentials');
+    if (!user || !user.isActive || !user.passwordHash) {
+      throw new UnauthorizedException('Invalid credentials');
+    }
     const ok = await argon2.verify(user.passwordHash, password);
     if (!ok) throw new UnauthorizedException('Invalid credentials');
     return user;
@@ -62,7 +66,7 @@ export class AuthService {
   }
 
   async issueRefresh(userId: string) {
-    const tokenId = crypto.randomUUID();
+    const tokenId = randomUUID();
     const ttl = 60 * 60 * 24 * 14; // 14d
     await this.redis.setex(`refresh:${tokenId}`, ttl, userId);
     return tokenId;
@@ -72,5 +76,44 @@ export class AuthService {
     const userId = await this.redis.get(`refresh:${refreshToken}`);
     if (!userId) throw new UnauthorizedException('Refresh expired or revoked');
     return userId;
+  }
+
+  async logout(refreshToken: string) {
+    await this.redis.del(`refresh:${refreshToken}`);
+  }
+
+  async loginWithWechat(code: string) {
+    const appid = process.env.WECHAT_APPID;
+    const secret = process.env.WECHAT_SECRET;
+    const url =
+      `https://api.weixin.qq.com/sns/jscode2session?appid=${appid}&secret=${secret}&js_code=${code}&grant_type=authorization_code`;
+    const data: any = await new Promise((resolve, reject) => {
+      https.get(url, res => {
+        let body = '';
+        res.on('data', chunk => (body += chunk));
+        res.on('end', () => {
+          try {
+            resolve(JSON.parse(body));
+          } catch (e) {
+            reject(e);
+          }
+        });
+      }).on('error', reject);
+    });
+    if (!data.openid) throw new UnauthorizedException('Invalid wechat code');
+
+    const existing = await this.prisma.userProvider.findUnique({
+      where: { provider_openId: { provider: 'WECHAT', openId: data.openid } },
+      include: { user: true },
+    });
+    if (existing) return existing.user;
+
+    const user = await this.prisma.userAccount.create({
+      data: {
+        providers: { create: { provider: 'WECHAT', openId: data.openid, unionId: data.unionid } },
+        identities: { create: { type: IdentityType.CONSUMER } },
+      },
+    });
+    return user;
   }
 }


### PR DESCRIPTION
## Summary
- allow optional email and password fields with a UserProvider relation for third-party logins
- support H5 credential and WeChat mini program login with refresh-token based logout
- generate refresh token identifiers using crypto `randomUUID`

## Testing
- `npm run prisma:generate -w apps/api`
- `npm run prisma:migrate:dev -w apps/api -- --name add-user-provider --create-only` *(fails: Can't reach database server at `localhost:3307`)*
- `npm run build -w apps/api` *(fails: nest: not found)*
- `npx -w apps/api tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_6899a0b67528832bbd018a296e10a5a3