### PR TITLE
feat: add phone and code login

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,21 @@ pnpm -C apps/api dev
 
 ### Default seed user
 - email: `admin@example.com`
+- phone: `18800000000`
 - password: `Passw0rd!`
 - identities: CONSUMER, MERCHANT(under demo tenant), WORKER
 
+### SMS
+To enable sending login codes via Aliyun, configure environment variables:
+- `ALIYUN_ACCESS_KEY_ID`
+- `ALIYUN_ACCESS_KEY_SECRET`
+- `ALIYUN_SMS_SIGN`
+- `ALIYUN_SMS_TEMPLATE`
+
 ### API
-- `POST /auth/login { email, password, identityId?, tenantId? }`
+- `POST /auth/sms { phone }`
+- `POST /auth/login { phone, password?, code?, identityId?, tenantId? }`
+- `POST /auth/login/wechat { code }`
 - `POST /auth/refresh { refreshToken }`
 - `POST /auth/switch-identity { identityId, tenantId? }` (requires Authorization Bearer)
 - `GET /me` (requires Authorization Bearer)

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -27,7 +27,7 @@ async function main() {
   const user = await prisma.userAccount.upsert({
     where: { email: 'admin@example.com' },
     update: {},
-    create: { email: 'admin@example.com', passwordHash: hash },
+    create: { email: 'admin@example.com', phone: '18800000000', passwordHash: hash },
   });
 
   const consumerId = await prisma.identity.upsert({
@@ -54,7 +54,7 @@ async function main() {
     create: { id: 'm_demo_merchant_admin', userId: user.id, tenantId: tenant.id, roleId: roleMerchantAdmin.id, defaultIdentityId: merchantId.id },
   });
 
-  console.log('Seed completed. Login with admin@example.com / Passw0rd!');
+  console.log('Seed completed. Login with 18800000000 / Passw0rd!');
 }
 
 main().catch((e) => { console.error(e); process.exit(1); }).finally(async () => { await prisma.$disconnect(); });

--- a/apps/api/src/modules/auth/auth.controller.ts
+++ b/apps/api/src/modules/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, HttpCode, Post, UseGuards } from '@nestjs/common';
+import { BadRequestException, Body, Controller, Get, HttpCode, Post, UseGuards } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { JwtAccessGuard } from './guards/jwt-access.guard';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
@@ -6,14 +6,22 @@ import { IdentityService } from '../identity/identity.service';
 
 /** 登录请求体 */
 class LoginDto {
-  /** 用户邮箱 */
-  email!: string;
-  /** 登录密码 */
-  password!: string;
+  /** 用户手机号 */
+  phone!: string;
+  /** 登录密码，可选 */
+  password?: string;
+  /** 短信验证码，可选 */
+  code?: string;
   /** 期望切换的身份ID，可选 */
   identityId?: string;
   /** 期望切换的租户ID，可选 */
   tenantId?: string;
+}
+
+/** 请求短信验证码 */
+class SmsDto {
+  /** 用户手机号 */
+  phone!: string;
 }
 
 /** 刷新/登出请求体 */
@@ -45,12 +53,29 @@ export class AuthController {
   constructor(private readonly auth: AuthService, private readonly identity: IdentityService) {}
 
   /**
-   * 使用账号密码登录
+   * 发送登录短信验证码
+   */
+  @Post('auth/sms')
+  @HttpCode(200)
+  async sendSms(@Body() dto: SmsDto) {
+    await this.auth.sendPhoneCode(dto.phone);
+    return { ok: true };
+  }
+
+  /**
+   * 使用手机号登录（密码或短信验证码）
    */
   @Post('auth/login')
   @HttpCode(200)
   async login(@Body() dto: LoginDto) {
-    const user = await this.auth.validateUser(dto.email, dto.password); // 校验账号密码
+    let user;
+    if (dto.password) {
+      user = await this.auth.validatePhonePassword(dto.phone, dto.password); // 校验手机号密码
+    } else if (dto.code) {
+      user = await this.auth.loginWithPhoneCode(dto.phone, dto.code); // 使用短信验证码登录或注册
+    } else {
+      throw new BadRequestException('password or code is required');
+    }
     const accessToken = await this.auth.issueAccess(user.id, dto.identityId, dto.tenantId); // 签发访问令牌
     const refreshToken = await this.auth.issueRefresh(user.id); // 签发刷新令牌
     const identities = await this.identity.listUserIdentities(user.id); // 获取当前账号的所有身份


### PR DESCRIPTION
## Summary
- allow logging in with phone + password or SMS code
- update seed and docs for phone-based login
- document wechat mini-program login endpoint
- send login codes via Aliyun SMS service and expose request endpoint

## Testing
- `pnpm -C apps/api prisma:generate`
- `pnpm -C apps/api build`


------
https://chatgpt.com/codex/tasks/task_e_689ad555ca38832bafad8df5c1803628