### PR TITLE
docs: document ALIYUN_REGION for SMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ Or with GitHub CLI:
 gh repo create o2o-identity-skeleton --public --source=. --remote=origin --push
 ```
 
+## SMS
+
+- `ALIYUN_REGION` (optional): Region for Aliyun SMS API, defaults to `cn-hangzhou`. This must match the region configured in your Aliyun SMS account.
+
 ## Notes
 - Access token TTL = 15m. Refresh tokens are stored in Redis for 14 days and can be revoked.
 - This is intentionally a **single service**. Breaking out microservices later won't require auth rewrites.


### PR DESCRIPTION
## Summary
- document `ALIYUN_REGION` in README's SMS section with default `cn-hangzhou`

## Testing
- `pnpm -C apps/api build` *(fails: Module '@prisma/client' has no exported member 'IdentityType')*

------
https://chatgpt.com/codex/tasks/task_e_689ada09a6a8832b990bf36d2b5304db