### PR TITLE
fix: resolve auth build errors

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -11,3 +11,10 @@ DATABASE_URL="mysql://root:root@localhost:3307/identity"
 
 # Redis
 REDIS_URL="redis://localhost:6380/0"
+
+# Aliyun SMS
+ALIYUN_ACCESS_KEY_ID=your_access_key_id
+ALIYUN_ACCESS_KEY_SECRET=your_access_key_secret
+ALIYUN_REGION=cn-hangzhou
+ALIYUN_SMS_SIGN=your_sms_sign
+ALIYUN_SMS_TEMPLATE=your_sms_template

--- a/apps/api/src/modules/auth/auth.controller.ts
+++ b/apps/api/src/modules/auth/auth.controller.ts
@@ -3,23 +3,21 @@ import { AuthService } from './auth.service';
 import { JwtAccessGuard } from './guards/jwt-access.guard';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
 import { IdentityService } from '../identity/identity.service';
-import { IsEmail, IsNotEmpty, IsOptional, IsString, IsUUID } from 'class-validator';
+import { IsNotEmpty, IsOptional, IsString, IsUUID } from 'class-validator';
 
 /** 登录请求体 */
 class LoginDto {
-  /** 用户邮箱 */
-  @IsEmail()
-  @IsNotEmpty()
-  email!: string;
-  /** 登录密码 */
+  /** 用户手机号 */
   @IsString()
   @IsNotEmpty()
-  password!: string;
-  /** 用户手机号 */
   phone!: string;
   /** 登录密码，可选 */
+  @IsString()
+  @IsOptional()
   password?: string;
   /** 短信验证码，可选 */
+  @IsString()
+  @IsOptional()
   code?: string;
   /** 期望切换的身份ID，可选 */
   @IsUUID()
@@ -34,6 +32,8 @@ class LoginDto {
 /** 请求短信验证码 */
 class SmsDto {
   /** 用户手机号 */
+  @IsString()
+  @IsNotEmpty()
   phone!: string;
 }
 
@@ -56,6 +56,8 @@ class WechatLoginDto {
 /** 发送手机验证码请求体 */
 class PhoneCodeDto {
   /** 手机号 */
+  @IsString()
+  @IsNotEmpty()
   phone!: string;
 }
 


### PR DESCRIPTION
## Summary
- document required Aliyun SMS environment variables with placeholder defaults
- clean up auth controller/service duplications to restore build
- restore SMS helpers with cooldown, env validation, and auth/sms endpoint

## Testing
- `pnpm -F api prisma:generate`
- `pnpm -F api build`


------
https://chatgpt.com/codex/tasks/task_e_689ae1e7fb44832b8e1331f39e132f94